### PR TITLE
Added serverside AES256

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,13 @@ resource "aws_s3_bucket" "input_bucket" {
   bucket = var.transcoding_input_bucket
   acl = "private"
 
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = var.sse_algorithm
+      }
+    }
+  }
   tags = {
     Name = "ExampleAppServerInstance"
   }
@@ -26,6 +33,15 @@ resource "aws_s3_bucket" "input_bucket" {
 resource "aws_s3_bucket" "output_bucket" {
   bucket = var.transcoding_output_bucket
   acl = "private"
+
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = var.sse_algorithm
+      }
+    }
+  }
 
   tags = {
     Name = "ExampleAppServerInstance"


### PR DESCRIPTION
KMS not supported

terraform plan

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_s3_bucket.input_bucket will be created
  + resource "aws_s3_bucket" "input_bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = (known after apply)
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = {
          + "Name" = "ExampleAppServerInstance"
        }
      + tags_all                    = {
          + "Name" = "ExampleAppServerInstance"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + server_side_encryption_configuration {
          + rule {
              + apply_server_side_encryption_by_default {
                  + sse_algorithm = "AES256"
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }
    }